### PR TITLE
:bug: Fix Timezone Conversion

### DIFF
--- a/src/clock/clock.cpp
+++ b/src/clock/clock.cpp
@@ -1,11 +1,23 @@
 #include "clock/clock.hpp"
 
-Clock::Clock(const char *ntpAddress, long offset, unsigned long updateInterval) :
+Clock::Clock(const char *ntpAddress, long offset, const char *tzstring, unsigned long updateInterval) :
         udpClient(), 
-        ntpClient(udpClient, ntpAddress, offset, updateInterval) {}
+        ntpClient(udpClient, ntpAddress, offset, updateInterval) {
+            configTzTime(tzstring, nullptr);
+        }
 
 const String Clock::getFormattedTime() {
-    return this->ntpClient.getFormattedTime();
+    time_t epoch = this->ntpClient.getEpochTime();
+    struct tm *timeInfo = localtime(&epoch);
+    int hours = timeInfo->tm_hour;
+    int minutes = timeInfo->tm_min;
+    int seconds = timeInfo->tm_sec;
+
+    String hoursStr = hours < 10 ? "0" + String(hours) : String(hours);
+    String minuteStr = minutes < 10 ? "0" + String(minutes) : String(minutes);
+    String secondStr = seconds < 10 ? "0" + String(seconds) : String(seconds);
+
+    return hoursStr + ":" + minuteStr + ":" + secondStr;
 }
 
 const String Clock::getFormattedDate() {

--- a/src/clock/clock.hpp
+++ b/src/clock/clock.hpp
@@ -6,7 +6,7 @@
 
 class Clock {
     public:
-        Clock(const char *ntpAddress, long offset, unsigned long updateInterval);
+        Clock(const char *ntpAddress, long offset, const char *tzstring, unsigned long updateInterval);
 
         /**
          * @brief Returns a String which contains the formatted time. 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,6 +69,7 @@ void loop() {
     logln(nullptr, "Updating Temperature Sensor");
     updatetime += tmpsensor.update();
     startmil = millis();
+    clk.update();
   }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,7 +13,7 @@
 
 char logbuffer[512];
 
-Clock clk(NTP_ADDRESS, NTP_OFFSET, NTP_INTERVAL);
+Clock clk(NTP_ADDRESS, NTP_OFFSET, NTP_POSIX_TIMEZONESTRING, NTP_INTERVAL);
 TempSensor tmpsensor(D4);
 WiFiClient wificlient;
 MqttClient mqttClient(wificlient, tmpsensor);


### PR DESCRIPTION
Adds the ability to set a specific timezone so that `time.h` internally knows how to handle the time conversion according to the correct timezone. 

Closes #1 