### PR TITLE
:sparkles: Publish the Temperature and Humidity Readings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "files.associations": {
         "cstdarg": "cpp",
-        "string": "cpp"
+        "string": "cpp",
+        "cmath": "cpp"
     }
 }

--- a/src/display/display.cpp
+++ b/src/display/display.cpp
@@ -90,13 +90,30 @@ void digitalClockFrame(OLEDDisplay *display, OLEDDisplayUiState* state, int16_t 
 
 void temperatureHumidFrame(OLEDDisplay *display, OLEDDisplayUiState* state, int16_t x, int16_t y) {
     DISPLAY_OBJECTS *dispobjects = (DISPLAY_OBJECTS*) state->userData;
+    char formatBuffer[7];
+
+    float temp = dispobjects->tempSensor.getTemperature();
+    float humid = dispobjects->tempSensor.getHumid();
 
     display->setFont(ArialMT_Plain_16);
+
     // Draw Temperature String
-    String tempstring = "Temp: " + dispobjects->tempSensor.getTemperature();
+    if(isnan(temp)) {
+        sprintf(formatBuffer, "---");
+    } else {
+        sprintf(formatBuffer, "%.1f°C", temp);
+    }
+    
+    String tempstring = "Temp: " + String(formatBuffer);
     display->drawString(10, 10, tempstring);
 
     // Draw Humidity String
-    String humidString = "Humid: " + dispobjects->tempSensor.getHumid();
+    if(isnan(humid)) {
+        sprintf(formatBuffer, "---");
+    } else {
+        sprintf(formatBuffer, "%.1f%%", humid);
+    }
+
+    String humidString = "Humid: " + String(formatBuffer);
     display->drawString(10, 30, humidString);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,7 @@ char logbuffer[512];
 Clock clk(NTP_ADDRESS, NTP_OFFSET, NTP_POSIX_TIMEZONESTRING, NTP_INTERVAL);
 TempSensor tmpsensor(D4);
 WiFiClient wificlient;
-MqttClient mqttClient(wificlient, tmpsensor);
+MqttClient mqttClient(wificlient, tmpsensor, MQTT_ROOT_TOPIC);
 
 DISPLAYCONFIG dconfig = {128, 64, D2, D1};
 DISPLAY_OBJECTS dobj = {clk, tmpsensor};
@@ -62,14 +62,24 @@ void setup() {
   startmil = millis();
 }
 
+char logbuff[128];
 void loop() {
   unsigned int updatetime = display.update();
 
   if (millis() - startmil >= 5000) {
     logln(nullptr, "Updating Temperature Sensor");
     updatetime += tmpsensor.update();
-    startmil = millis();
+    
+    sprintf(logbuff, "Publishing Results to MQTT Server: %s\n", MQTT_SERVER);
+    logln(nullptr, logbuff);
+    mqttClient.publishTempHumidMeasurements();
+
+    logln(nullptr, "Publishing heartbeat message");
+    mqttClient.publishHeartbeat();
+
+    logln(nullptr, "Updating Clock");
     clk.update();
+    startmil = millis();
   }
 
 

--- a/src/mqttclient/mqttclient.cpp
+++ b/src/mqttclient/mqttclient.cpp
@@ -62,11 +62,15 @@ unsigned long MqttClient::publishHeartbeat() {
 
 unsigned long MqttClient::publishTempHumidMeasurements() {
     unsigned long startmillis = millis();
-    String temperature = this->tempsensor.getTemperature();
-    String humid = this->tempsensor.getHumid();
+    char formatBuffer[7];
+    float temperature = this->tempsensor.getTemperature();
+    float humid = this->tempsensor.getHumid();
 
-    this->publishMessage(this->root_topic + "/temperature", temperature);
-    this->publishMessage(this->root_topic + "/humid", humid);
+    sprintf(formatBuffer, "%.1f", temperature);
+    this->publishMessage(this->root_topic + "/temperature", formatBuffer);
+
+    sprintf(formatBuffer, "%.1f", humid);
+    this->publishMessage(this->root_topic + "/humid", formatBuffer);
 
     return millis() - startmillis;
 }

--- a/src/mqttclient/mqttclient.cpp
+++ b/src/mqttclient/mqttclient.cpp
@@ -1,8 +1,9 @@
 #include "mqttclient/mqttclient.hpp"
 
-MqttClient::MqttClient(WiFiClient &wifiClient, TempSensor &tempsensor): 
+MqttClient::MqttClient(WiFiClient &wifiClient, TempSensor &tempsensor, String root_topic): 
     mqttClient(PubSubClient(wifiClient)),
-    tempsensor(tempsensor) {
+    tempsensor(tempsensor),
+    root_topic(root_topic) {
 }
 
 MQTT_CONNECT_STATE MqttClient::reconnect(SSD1306Wire *disp) {
@@ -52,13 +53,20 @@ boolean MqttClient::publishMessage(const String &topic, const String &message) {
     return publish_success;
 }
 
-unsigned long MqttClient::publishTempHumidMeasurements(const String &topic) {
+unsigned long MqttClient::publishHeartbeat() {
+    unsigned long startmillis = millis();
+    this->publishMessage(this->root_topic + "/heartbeat", "alive");
+
+    return millis() - startmillis;
+}
+
+unsigned long MqttClient::publishTempHumidMeasurements() {
     unsigned long startmillis = millis();
     String temperature = this->tempsensor.getTemperature();
     String humid = this->tempsensor.getHumid();
 
-    this->publishMessage(topic + "/temperature", temperature);
-    this->publishMessage(topic + "/humid", humid);
+    this->publishMessage(this->root_topic + "/temperature", temperature);
+    this->publishMessage(this->root_topic + "/humid", humid);
 
     return millis() - startmillis;
 }

--- a/src/mqttclient/mqttclient.hpp
+++ b/src/mqttclient/mqttclient.hpp
@@ -18,9 +18,10 @@ class MqttClient {
          * 
          * @param WiFiClient Wifi Client which should be used for MQTT Connections.
          * @param tempsensor Reference to an already initialized tempsensor object.
+         * @param root_topic The root topic which will be used to publish MQTT messages. This must NOT end with a /. 
          * 
          */
-        MqttClient(WiFiClient &wifiClient, TempSensor &tempsensor);
+        MqttClient(WiFiClient &wifiClient, TempSensor &tempsensor, String root_topic);
 
         /**
          * @brief Initialize and connect the MQTT - Client.
@@ -42,13 +43,23 @@ class MqttClient {
          * 
          * @return uint8_t The number of Millis the operation took. 
          */
-        unsigned long publishTempHumidMeasurements(const String &topic);
+        unsigned long publishTempHumidMeasurements();
+
+
+        /**
+         * @brief Publishes a heratbeat message to the MQTT - Server on the specfied topic to
+         * indicate, that the node is still alive.
+         * 
+         * @return unsigned long The number of Millis the operation took. 
+         */
+        unsigned long publishHeartbeat();
 
     private:
         PubSubClient mqttClient;
         TempSensor tempsensor;
 
         boolean publishMessage(const String &topic, const String &message);
+        String root_topic;
 };
 
 

--- a/src/mqttclient/mqttclient.hpp
+++ b/src/mqttclient/mqttclient.hpp
@@ -56,7 +56,7 @@ class MqttClient {
 
     private:
         PubSubClient mqttClient;
-        TempSensor tempsensor;
+        TempSensor &tempsensor;
 
         boolean publishMessage(const String &topic, const String &message);
         String root_topic;

--- a/src/tempsensor/tempsensor.cpp
+++ b/src/tempsensor/tempsensor.cpp
@@ -13,32 +13,24 @@ unsigned long TempSensor::update() {
     this->temperature = this->dhtSensor.readTemperature();
     this->humid = this->dhtSensor.readHumidity();
 
+    if (isnan(this->temperature)) {
+        Serial.println("Failed to Read Temperature from DHT Sensor!");
+    }
+    
+    if (isnan(this->humid)) {
+        Serial.println("Failed to Read Humidity from DHT Sensor!");
+    } 
+
     Serial.printf("Sensor Updated - Temperature: %f C Humid: %f\n", this->temperature, this->humid);
 
     return millis() - start_millis;
 }
 
-const String TempSensor::getTemperature() {
-    char formatBuffer[7];
-
-    if (isnan(this->temperature)) {
-        Serial.println("Failed to Read Temperature from DHT Sensor!");
-        return "";
-    }
-
-    sprintf(formatBuffer, "%.1f\xB0 C", this->temperature);
-    return String(formatBuffer);    
+float TempSensor::getTemperature() {
+    return this->temperature;
 }
 
-const String TempSensor::getHumid() {
-    char formatBuffer[7];
-
-    if (isnan(this->humid)) {
-        Serial.println("Failed to Read Humidity from DHT Sensor!");
-        return "";
-    }
-
-    sprintf(formatBuffer, "%.1f\x25", this->humid);
-    return String(formatBuffer);    
+float TempSensor::getHumid() {
+    return this->humid;
 }
 

--- a/src/tempsensor/tempsensor.hpp
+++ b/src/tempsensor/tempsensor.hpp
@@ -22,20 +22,20 @@ class TempSensor {
         unsigned long update();
 
         /**
-         * @brief Reads and returns the current Temperature read by the Sensor or an
-         * empty string, if the reading failed.
+         * @brief Returns the last measured temperature value of the sensor. Call update() to
+         * update the value.
          * 
-         * @return const String Temperature or empty, if reading failed
+         * @return float last measured temperature or TEMP_READING_FAILED if the last update failed.
          */
-        const String getTemperature();
+        float getTemperature();
 
         /**
-         * @brief Reads and returns the current Humidity read by the Sensor or an
-         * empty string, if the reading failed.
+         * @brief Returns the last measured humidity value of the sensor. Call update() to
+         * update the value.
          * 
-         * @return const String Humidity or empty, if reading failed
+         * @return float last measured humidity or HUMID_READING_FAILED if the last update failed.
          */
-        const String getHumid();
+        float getHumid();
 
     private:
         DHT dhtSensor;


### PR DESCRIPTION
This PR actually enables the publishing of the temperature and humidity readings to the specified MQTT - Server, using the given `MQTT_ROOT_TOPIC` variable defined in the `settings.hpp` file. 