### PR TITLE
Differentiate the Update from the Publish interval

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,7 +23,8 @@ DISPLAY_OBJECTS dobj = {clk, tmpsensor};
 
 Display display(&dconfig, &dobj);
 
-unsigned int startmil = 0;
+unsigned long update_millis = 0;
+unsigned long publish_millis = 0;
 
 void setup() {
   Serial.begin(74880);
@@ -59,30 +60,35 @@ void setup() {
   // Connecting MQTT
   mqttClient.initialize(MQTT_SERVER, MQTT_PORT, rawDisplay);
   logln(rawDisplay, "MQTT Initialized");
-  startmil = millis();
+  
+  update_millis = millis();
+  publish_millis = millis();
 }
 
 char logbuff[128];
 void loop() {
   unsigned int updatetime = display.update();
 
-  if (millis() - startmil >= 5000) {
+  if (millis() - update_millis >= UPDATE_INTERVAL) {
     logln(nullptr, "Updating Temperature Sensor");
     updatetime += tmpsensor.update();
-    
-    sprintf(logbuff, "Publishing Results to MQTT Server: %s\n", MQTT_SERVER);
-    logln(nullptr, logbuff);
-    mqttClient.publishTempHumidMeasurements();
 
     logln(nullptr, "Publishing heartbeat message");
     mqttClient.publishHeartbeat();
 
     logln(nullptr, "Updating Clock");
     clk.update();
-    startmil = millis();
+
+    update_millis = millis();
   }
 
-
+  if (millis() - publish_millis >= MQTT_PUBLISH_INTERVAL) {
+    sprintf(logbuff, "Publishing Results to MQTT Server: %s\n", MQTT_SERVER);
+    logln(nullptr, logbuff);
+    mqttClient.publishTempHumidMeasurements();
+    
+    publish_millis = millis();
+  }
   
   delay(1000 - updatetime);
 }


### PR DESCRIPTION
Currently, all values are published to the MQTT - Server every 5 seconds. For a temperature and humidity measurement, I do not want to store so many values on my influxdb. 

With this PR, both intervals will be decoupled so that the measurements on the display are still updated every 5 seconds but the values whose are published are only published every minute. 